### PR TITLE
Add getBoundingBoxes getter to SelectableFragment class

### DIFF
--- a/lib/src/selectable_fragment.dart
+++ b/lib/src/selectable_fragment.dart
@@ -615,6 +615,14 @@ class SelectableFragment
   }
 
   @override
+  List<Rect> get boundingBoxes => paragraph
+      .getBoxesForSelection(
+        TextSelection(baseOffset: range.start, extentOffset: range.end),
+      )
+      .map((box) => box.toRect())
+      .toList();
+
+  @override
   TextRange getWordBoundary(TextPosition position) =>
       paragraph.getWordBoundary(position);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: float_column
 description: Flutter FloatColumn widget for building a vertical column of widgets and text where the text wraps around floated widgets, similar to how CSS float works.
-version: 2.1.1
+version: 2.1.2
 repository: https://github.com/ronjb/float_column
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: '>=3.10.0'
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This fixes the error introduced with Flutter 3.19.0